### PR TITLE
fixed relativenumbers for newer vim versions

### DIFF
--- a/plugin/ctrlspace.vim
+++ b/plugin/ctrlspace.vim
@@ -2401,7 +2401,6 @@ function! <SID>set_status_line()
 endfunction
 
 function! <SID>set_up_buffer()
-  setlocal noshowcmd
   setlocal noswapfile
   setlocal buftype=nofile
   setlocal bufhidden=delete
@@ -2409,6 +2408,9 @@ function! <SID>set_up_buffer()
   setlocal nomodifiable
   setlocal nowrap
   setlocal nonumber
+  if exists('+relativenumber')
+    setlocal norelativenumber
+  endif
   setlocal nocursorcolumn
   setlocal nocursorline
 


### PR DESCRIPTION
relativenumbers are useless in ctrl-space window because you change tabs with numbers so i removed them if relativenumber feature is available

removed "setlocal noshowcmd" because it sets the global value and showcmd is deactivated after invoking ctrl-space the first time
