### PR TITLE
Close preview window before showing ctrlspace

### DIFF
--- a/plugin/ctrlspace.vim
+++ b/plugin/ctrlspace.vim
@@ -1382,6 +1382,8 @@ function! <SID>ctrlspace_toggle(internal)
       endif
     endif
   elseif !a:internal
+    " make sure preview window is closed
+    silent! exe "pclose"
     let t:ctrlspace_start_window = winnr()
     let t:ctrlspace_winrestcmd = winrestcmd()
   endif


### PR DESCRIPTION
I would like to add a small update to your plugin. Opening "ctrlspace" window is messing around with my window layout when the "preview" is shown.
For me closing "preview" solves the problem.
