### PR TITLE
Fixed wrong current directory while creating a new Bookmark

### DIFF
--- a/autoload/ctrlspace/bookmarks.vim
+++ b/autoload/ctrlspace/bookmarks.vim
@@ -99,12 +99,8 @@ function! ctrlspace#bookmarks#AddFirstBookmark()
 endfunction
 
 function! ctrlspace#bookmarks#AddNewBookmark(...)
-	if a:0
-		let current = s:bookmarks[a:1].Directory
-	else
-		let root    = ctrlspace#roots#CurrentProjectRoot()
-		let current = empty(root) ? fnamemodify(".", ":p:h") : root
-	endif
+  let root    = ctrlspace#roots#CurrentProjectRoot()
+  let current = empty(root) ? fnamemodify(".", ":p:h") : root
 
 	let directory = ctrlspace#ui#GetInput("Add directory to bookmarks: ", current, "dir")
 

--- a/autoload/ctrlspace/keys/bookmark.vim
+++ b/autoload/ctrlspace/keys/bookmark.vim
@@ -53,11 +53,7 @@ function! ctrlspace#keys#bookmark#Edit(k)
 endfunction
 
 function! ctrlspace#keys#bookmark#Add(k)
-	if a:k ==# "a"
-		let result = ctrlspace#bookmarks#AddNewBookmark(ctrlspace#window#SelectedIndex())
-	else
-		let result = ctrlspace#bookmarks#AddNewBookmark()
-	endif
+  let result = ctrlspace#bookmarks#addnewbookmark()
 
 	if result
 		call ctrlspace#window#Kill(0, 1)


### PR DESCRIPTION
The first time I added a Bookmark (`<a>`) everything went well. But the following I added took the directory of the "visually selected one" instead of its own.

![screenshot from 2016-02-25 00-03-13](https://cloud.githubusercontent.com/assets/1272617/13304144/65ac5f78-db53-11e5-8ccc-2e828d17ebde.png)
