### PR TITLE
Updated help file to reflect current default keybindings

### DIFF
--- a/doc/ctrlspace.txt
+++ b/doc/ctrlspace.txt
@@ -169,8 +169,8 @@ more info.
 2. Idea by Analogy                                          *ctrlspace-idea*
 
 Vim-CtrlSpace interface is a window you can invoke by pressing <C-Space>.
-The window displays a list of items. You can select those items with <h>,
-<j>, and <CR> keys.
+The window displays a list of items. You can select those items with <j>,
+<k>, and <CR> keys.
 
 Generally speaking Vim-CtrlSpace can display 5 types of lists:
 


### PR DESCRIPTION
Very small change to the vim help file as the j/k scrolling keys were misidentified.