### PR TITLE
Save all named buffers when saving a workspace

### DIFF
--- a/autoload/ctrlspace/workspaces.vim
+++ b/autoload/ctrlspace/workspaces.vim
@@ -360,7 +360,7 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 		let bufs = []
 
 		for [nr, bname] in items(ctrlspaceList)
-			let bufname = filereadable(bname) ? fnamemodify(bname, ":.") : bname
+			let bufname = filereadable(bname) ? fnameescape(fnamemodify(bname, ":.")) : bname
 			call add(bufs, bufname)
 		endfor
 
@@ -403,7 +403,7 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 			endif
 
 			for b in data.bufs
-				call s:addMapped(lines, 'edit', fnameescape(b))
+				call s:addMapped(lines, 'edit', b)
 			endfor
 
 			if !empty(data.label)
@@ -421,6 +421,8 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 			endif
 
 			let tabIndex += 1
+		elseif cmd == 'edit'
+			call s:addMapped(lines, cmd, filereadable(args) ? args : expand(args))
 		else
 			call s:addMapped(lines, cmd, args)
 		endif
@@ -456,11 +458,11 @@ function! s:addMapped(lines, cmd, args)
 		call add(a:lines, a:cmd . ' ' . a:args)
 	elseif index(s:termbuffers, a:args) >= 0
 		" A terminal buffer has already been added to a:termbuffers
-		call add(a:lines, 'exe "' . a:cmd . ' " . s:termbuffers[''' . a:args . ''']')
+		call add(a:lines, 'exe "' . a:cmd . ' " . s:termbuffers[' . string(a:args) . ']')
 	else
 		" Buffer has not yet been added
 		call add(a:lines, a:cmd . ' ' . a:args)
-		call add(a:lines, 'let s:termbuffers[''' . a:args . ''']=buffer_name(''%'')')
+		call add(a:lines, 'let s:termbuffers[' . string(a:args) . ']=buffer_name(''%'')')
 		call add(s:termbuffers, a:args)
 	endif
 endfunction

--- a/autoload/ctrlspace/workspaces.vim
+++ b/autoload/ctrlspace/workspaces.vim
@@ -381,7 +381,7 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 	let tabIndex = 0
 
 	for cmd in readfile("CS_SESSION")
-		if cmd =~# "^lcd"
+		if cmd =~# "^lcd" || cmd =~# '^badd +\d\+ term://'
 			continue
 		elseif ((cmd =~# "^edit") && (tabIndex == 0)) || (cmd =~# "^tabnew") || (cmd =~# "^tabedit")
 			let data = tabData[tabIndex]

--- a/autoload/ctrlspace/workspaces.vim
+++ b/autoload/ctrlspace/workspaces.vim
@@ -383,7 +383,7 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 	call add(lines, 'let s:termbuffers = {}')
 
 	for line in readfile("CS_SESSION")
-		let l:match = matchlist(line, '\m^\([a-z]\+\) \(.*\)$')
+		let l:match = matchlist(line, '\m^\([a-z]\+\)\%(\| \s*\(.*\)\)$')
 
 		if !exists("l:match[0]")
 			call add(lines, line)

--- a/autoload/ctrlspace/workspaces.vim
+++ b/autoload/ctrlspace/workspaces.vim
@@ -359,12 +359,7 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 		let bufs = []
 
 		for [nr, bname] in items(ctrlspaceList)
-			let bufname = fnamemodify(bname, ":.")
-
-			if !filereadable(bufname)
-				continue
-			endif
-
+			let bufname = filereadable(bname) ? fnamemodify(bname, ":.") : bname
 			call add(bufs, bufname)
 		endfor
 
@@ -415,11 +410,7 @@ function! ctrlspace#workspaces#SaveWorkspace(name)
 
 			let tabIndex += 1
 		else
-			let baddList = matchlist(cmd, "\\m^badd \+\\d* \\(.*\\)$")
-
-			if !(exists("baddList[1]") && !empty(baddList[1]) && !filereadable(baddList[1]))
-				call add(lines, cmd)
-			endif
+			call add(lines, cmd)
 		endif
 	endfor
 


### PR DESCRIPTION
Removes the restriction when saving a workspace that named buffers are
readable files.  Not all named buffers correspond to readable files;
for example URLs (downloaded by netrw) and terminal buffers in neovim.

This happens to address the closed issue
https://github.com/vim-ctrlspace/vim-ctrlspace/issues/110