### PR TITLE
Force update tabline on :CtrlSpaceTabLabel

### DIFF
--- a/autoload/ctrlspace/tabs.vim
+++ b/autoload/ctrlspace/tabs.vim
@@ -4,6 +4,11 @@ let s:modes  = ctrlspace#modes#Modes()
 function! ctrlspace#tabs#SetTabLabel(tabnr, label, auto)
 	call settabvar(a:tabnr, "CtrlSpaceLabel", a:label)
 	call settabvar(a:tabnr, "CtrlSpaceAutotab", a:auto)
+	if get(g:, 'loaded_airline', 0)
+		" Force Update of tabline in airline
+		call airline#extensions#tabline#ctrlspace#invalidate()
+		sil doautocmd <nomodeline> TabEnter
+	endif
 endfunction
 
 function! ctrlspace#tabs#NewTabLabel(tabnr)


### PR DESCRIPTION
This fixes vim-airline/vim-airline#1808

Currently, when running :CtrlSpaceTabLabel the tabline is not
immediately updated. So force an update for Airline if airline exists.

Note: <nomodeline> is only available since 7.3.438