### PR TITLE
fix engine path with spaces

### DIFF
--- a/autoload/ctrlspace/engine.vim
+++ b/autoload/ctrlspace/engine.vim
@@ -49,7 +49,7 @@ function! s:contentFromFileEngine()
 				\ ',"Source":"' . escape(fnamemodify(ctrlspace#util#FilesCache(), ":p"), '\"') .
 				\ '","Dots":"' . s:config.Symbols.Dots . '","DotsSize":' . ctrlspace#context#SymbolSizes().Dots . '}'
 
-	let results  = split(system(s:config.FileEngine, context), "\n")
+	let results  = split(system(shellescape(s:config.FileEngine), context), "\n")
 	let patterns = eval(results[0])
 	let indices  = eval(results[1])
 	let size     = str2nr(results[2])

--- a/autoload/ctrlspace/files.vim
+++ b/autoload/ctrlspace/files.vim
@@ -33,7 +33,7 @@ function! ctrlspace#files#CollectFiles()
 
 			let uniqueFiles = {}
 
-			for fname in empty(s:config.GlobCommand) ? split(globpath('.', '**'), '\n') : split(system(s:config.GlobCommand), '\n')
+			for fname in empty(s:config.GlobCommand) ? split(globpath('.', '**'), '\n') : split(system(shellescape(s:config.GlobCommand)), '\n')
 				let fnameModified = fnamemodify(has("win32") ? substitute(fname, "\r$", "", "") : fname, ":.")
 
 				if isdirectory(fnameModified) || (fnameModified =~# s:config.IgnoredFiles)


### PR DESCRIPTION
Solves https://github.com/vim-ctrlspace/vim-ctrlspace/issues/182

Maybe `shellescape()` is called for in other instances of `system(...)`. To be checked.