### PR TITLE
Add neovim instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,6 @@ cd ~/.vim
 git clone https://github.com/vim-ctrlspace/vim-ctrlspace.git .
 ```
 
-#### Neovim
-
-Neovim requires adding the following line to your `.vimrc`:
-
-```VimL
-let g:CtrlSpaceDefaultMappingKey = "<C-space> "
-```
-
-Note the trailing space at the end of the mapping. Neovim doesn't mind
-it, but it makes vim-ctrlspace's "is the mapping left at default" check 
-fail so it won't change the mapping to `<nul>`.
-
 ### Basic Settings
 
 First please make sure that you set `nocompatible` and `hidden` options
@@ -162,6 +150,19 @@ set showtabline=0
 Tabline in Vim has very limited capabilities and as Vim-CtrlSpace makes
 use of tabs intensively, tabline would just get in your way. **Tab List**
 (`<l>`) makes tabline obsolete ;).
+
+
+#### Neovim
+
+Neovim requires adding the following line to your `.vimrc` or `init.vim`:
+
+```VimL
+let g:CtrlSpaceDefaultMappingKey = "<C-space> "
+```
+
+Note the trailing space at the end of the mapping. Neovim doesn't mind
+it, but it makes vim-ctrlspace's "is the mapping left at default" check 
+fail so it won't change the mapping to `<nul>`.
 
 
 #### Go Engine

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ cd ~/.vim
 git clone https://github.com/vim-ctrlspace/vim-ctrlspace.git .
 ```
 
+#### Neovim
+
+Neovim requires adding the following line to your `.vimrc`:
+
+```VimL
+let g:CtrlSpaceDefaultMappingKey = "<C-space> "
+```
+
+Note the trailing space at the end of the mapping. Neovim doesn't mind
+it, but it makes vim-ctrlspace's "is the mapping left at default" check 
+fail so it won't change the mapping to `<nul>`.
+
 ### Basic Settings
 
 First please make sure that you set `nocompatible` and `hidden` options


### PR DESCRIPTION
Neovim is broken by default. As a user I was confused why this did not work, and searching the issues revealed:

#188 
#194 

There is an easy fix, but this fix is not visible nor intuitive for users. I propose adding this information to the doc so future neovim users can get up and running easily. This improves over the current state of users having to search closed issues to find a known fix.