### PR TITLE
escape shell command at correct location

### DIFF
--- a/autoload/ctrlspace/context.vim
+++ b/autoload/ctrlspace/context.vim
@@ -95,7 +95,7 @@ function! s:init()
 
 	if !empty(s:conf.FileEngine)
 		let s:conf.FileEngineName = s:conf.FileEngine
-		let ebin = s:pluginFolder . "/bin/" . s:conf.FileEngine
+		let ebin = shellescape(s:pluginFolder . "/bin/" . s:conf.FileEngine)
 		let s:conf.FileEngine = executable(ebin) ? ebin : ""
 	endif
 

--- a/autoload/ctrlspace/engine.vim
+++ b/autoload/ctrlspace/engine.vim
@@ -49,7 +49,7 @@ function! s:contentFromFileEngine()
 				\ ',"Source":"' . escape(fnamemodify(ctrlspace#util#FilesCache(), ":p"), '\"') .
 				\ '","Dots":"' . s:config.Symbols.Dots . '","DotsSize":' . ctrlspace#context#SymbolSizes().Dots . '}'
 
-	let results  = split(system(shellescape(s:config.FileEngine), context), "\n")
+	let results  = split(system(s:config.FileEngine, context), "\n")
 	let patterns = eval(results[0])
 	let indices  = eval(results[1])
 	let size     = str2nr(results[2])

--- a/autoload/ctrlspace/files.vim
+++ b/autoload/ctrlspace/files.vim
@@ -33,7 +33,7 @@ function! ctrlspace#files#CollectFiles()
 
 			let uniqueFiles = {}
 
-			for fname in empty(s:config.GlobCommand) ? split(globpath('.', '**'), '\n') : split(system(shellescape(s:config.GlobCommand)), '\n')
+			for fname in empty(s:config.GlobCommand) ? split(globpath('.', '**'), '\n') : split(system(s:config.GlobCommand), '\n')
 				let fnameModified = fnamemodify(has("win32") ? substitute(fname, "\r$", "", "") : fname, ":.")
 
 				if isdirectory(fnameModified) || (fnameModified =~# s:config.IgnoredFiles)


### PR DESCRIPTION
The shellescape would escape command parameters. Instead, only the path of the executable must be escaped. This is fixed in this pull request.