### PR TITLE
escape special percent sign in tabline by doubling it

### DIFF
--- a/autoload/ctrlspace/api.vim
+++ b/autoload/ctrlspace/api.vim
@@ -206,7 +206,7 @@ function! ctrlspace#api#TabTitle(tabnr, bufnr, bufname)
 		if empty(bufname)
 			let title = "[" . bufnr . "*No Name]"
 		else
-			let title = "[" . fnamemodify(bufname, ':t') . "]"
+			let title = "[" . substitute(fnamemodify(bufname, ':t'), '%', '%%', 'g') . "]"
 		endif
 	endif
 


### PR DESCRIPTION
Solves https://github.com/vim-ctrlspace/vim-ctrlspace/issues/176