### PR TITLE
Set foldmethod to default value

### DIFF
--- a/autoload/ctrlspace/window.vim
+++ b/autoload/ctrlspace/window.vim
@@ -395,6 +395,7 @@ function! s:setUpBuffer()
 	setlocal nolist
 	setlocal cc=
 	setlocal filetype=ctrlspace
+	setlocal foldmethod=manual
 
 	call ctrlspace#context#SetPluginBuffer(bufnr("%"))
 


### PR DESCRIPTION
This patch is a fix for issue #189.

It adds the local setting `foldmethod=manual` to the ctrlspace buffer window. This disables any folding within the buffer if `foldmethod=indent` is set globally.