### PR TITLE
Sort key help by description

### DIFF
--- a/autoload/ctrlspace/context.vim
+++ b/autoload/ctrlspace/context.vim
@@ -54,6 +54,7 @@ let s:configuration = {
                     \ "DefaultMappingKey":         "<C-Space>",
                     \ "Keys":                      {},
                     \ "Help":                      {},
+                    \ "SortHelp":                  0,
                     \ "GlobCommand":               "",
                     \ "UseTabline":                1,
                     \ "UseArrowsInTerm":           0,

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -319,7 +319,11 @@ function! s:sortKeyHelp(key1, key2) dict
 endfunction
 
 function! s:collectKeysInfo(mapName) abort
-    for key in sort(keys(s:helpMap[a:mapName]), "s:sortKeyHelp", s:helpMap[a:mapName])
+    let l:keys = keys(s:helpMap[a:mapName])
+    if s:config.SortHelp
+      let l:keys = sort(l:keys, "s:sortKeyHelp", s:helpMap[a:mapName])
+    endif
+    for key in l:keys
         let FnKey = s:helpMap[a:mapName][key]
 
         " Due to the way 'ctrlspace#keys#nop#_ExecDbmdexAction' is called (as

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -312,8 +312,14 @@ function! s:keyHelp(key, description) abort
     endif
 endfunction
 
+function! s:sortKeyHelp(key1, key2) dict
+    let l:desc1 = get(s:descriptions, self[a:key1], "")
+    let l:desc2 = get(s:descriptions, self[a:key2], "")
+    return l:desc1 == l:desc2 ? 0 : l:desc1 > l:desc2 ? 1 : -1
+endfunction
+
 function! s:collectKeysInfo(mapName) abort
-    for key in sort(keys(s:helpMap[a:mapName]))
+    for key in sort(keys(s:helpMap[a:mapName]), "s:sortKeyHelp", s:helpMap[a:mapName])
         let FnKey = s:helpMap[a:mapName][key]
 
         " Due to the way 'ctrlspace#keys#nop#_ExecDbmdexAction' is called (as

--- a/doc/ctrlspace.txt
+++ b/doc/ctrlspace.txt
@@ -78,6 +78,7 @@ Table of Contents                                            *ctrlspace-toc*
    7.20 g:CtrlSpaceStatuslineFunction        |g:CtrlSpaceStatuslineFunction|
    7.21 g:CtrlSpaceSearchTiming                    |g:CtrlSpaceSearchTiming|
    7.22 g:CtrlSpaceFileEngine                        |g:CtrlSpaceFileEngine|
+   7.23 g:CtrlSpaceSortHelp                            |g:CtrlSpaceSortHelp|
  8. API                                                      |ctrlspace-api|
    8.1 Commands                                         |ctrlspace-commands|
      8.1.1 :CtrlSpace [keys]                                    |:CtrlSpace|
@@ -1185,6 +1186,19 @@ just provide an empty string: >
 Default value: >
 
     let g:CtrlSpaceFileEngine = "auto"
+<
+                                                             |ctrlspace-toc|
+--------------------------------------------------------------------------
+
+7.23 *g:CtrlSpaceSortHelp*
+
+Enables sorting the lines in help mode by the description. This is disabled by
+default for backwards compatibility. In a future version sorting might become
+the new default though.
+
+Default value: >
+
+    let g:CtrlSpaceSortHelp = 0
 <
                                                              |ctrlspace-toc|
 ==========================================================================


### PR DESCRIPTION
As noted in #158, the current help for key mappings is hard to read.
This small change orders it by the descriptions instead of the keys themselves.
Now scanning for a available options is a little easier.
Proper grouping would be preferable of course, but would require a new datastructure