### PR TITLE
crudely surpress Hit Enter prompt

### DIFF
--- a/autoload/ctrlspace/init.vim
+++ b/autoload/ctrlspace/init.vim
@@ -42,6 +42,7 @@ function! ctrlspace#init#Init()
         let currBuff=bufnr('%')
 
         silent argdo call ctrlspace#buffers#AddBuffer()
+        silent argdo silent echo ''
         
         if curaltBuff >= 0 
             execute 'buffer ' . curaltBuff


### PR DESCRIPTION
Please tell me if there is a better way. Didn't find it.

Resolves https://github.com/vim-ctrlspace/vim-ctrlspace/commit/32430cd01760f761669442415335b0200632a2ae#commitcomment-34046051