### PR TITLE
Add Feature: Exception Keymaps in NOP Mode

### DIFF
--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -318,7 +318,7 @@ function! s:collectKeysInfo(mapName)
 
         if type(FnKey) == v:t_func && get(FnKey, 'name') == "ctrlspace#keys#nop#_ExecException"
             let [md, fn] = get(FnKey, 'args')
-            let extrInfo = ' (NOP + ' . toupper(md) . ' Modes Only)'
+            let extrInfo = ' (NOP + ' . toupper(md) . ' only)'
         elseif type(FnKey) == v:t_string
             let fn = FnKey
             let extrInfo = ''

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -316,9 +316,13 @@ function! s:collectKeysInfo(mapName)
     for key in sort(keys(s:helpMap[a:mapName]))
         let FnKey = s:helpMap[a:mapName][key]
 
+        " Due to the way 'ctrlspace#keys#nop#_ExecDbmdexAction' is called (as
+        " a Partial, in order to capture runtime info), it is keyed as a
+        " Funcref, instead of a string like other functions, in s:helpMap
+        " TODO: please improve if better implementation allowing use of string key is known
         if type(FnKey) == v:t_func && get(FnKey, 'name') == "ctrlspace#keys#nop#_ExecDbmdexAction"
             let [md, fn] = get(FnKey, 'args')
-            let fn = s:modes[md].Enabled ? fn : ''
+            let fn = s:modes[md].Enabled ? fn : ''    " only generate help if the appropriate mode is enabled
         elseif type(FnKey) == v:t_string
             let fn = FnKey
         endif

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -314,10 +314,19 @@ endfunction
 
 function! s:collectKeysInfo(mapName)
     for key in sort(keys(s:helpMap[a:mapName]))
-        let fn = s:helpMap[a:mapName][key]
+        let FnName = s:helpMap[a:mapName][key]
 
-        if has_key(s:descriptions, fn) && !empty(s:descriptions[fn])
-            call s:keyHelp(key, s:descriptions[fn])
+        if type(FnName) == v:t_func && get(FnName, 'name') == "ctrlspace#keys#nop#_ExecException"
+            let excpMode = get(FnName, 'args')[0]
+            let descFunc = get(FnName, 'args')[1]
+            let extrInfo = ' (NOP Mode exception with ' . toupper(excpMode) . ' LIST)'
+        elseif type(FnName) == v:t_string
+            let descFunc = FnName
+            let extrInfo = ''
+        endif
+
+        if has_key(s:descriptions, descFunc) && !empty(s:descriptions[descFunc])
+            call s:keyHelp(key, s:descriptions[descFunc] . extrInfo)
         endif
     endfor
 endfunction

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -318,14 +318,13 @@ function! s:collectKeysInfo(mapName)
 
         if type(FnKey) == v:t_func && get(FnKey, 'name') == "ctrlspace#keys#nop#_ExecException"
             let [md, fn] = get(FnKey, 'args')
-            let extrInfo = ' (NOP + ' . toupper(md) . ' only)'
+            let fn = s:modes[md].Enabled ? fn : ''
         elseif type(FnKey) == v:t_string
             let fn = FnKey
-            let extrInfo = ''
         endif
 
         if has_key(s:descriptions, fn) && !empty(s:descriptions[fn])
-            call s:keyHelp(key, s:descriptions[fn] . extrInfo)
+            call s:keyHelp(key, s:descriptions[fn])
         endif
     endfor
 endfunction

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -316,7 +316,7 @@ function! s:collectKeysInfo(mapName)
     for key in sort(keys(s:helpMap[a:mapName]))
         let FnKey = s:helpMap[a:mapName][key]
 
-        if type(FnKey) == v:t_func && get(FnKey, 'name') == "ctrlspace#keys#nop#_ExecException"
+        if type(FnKey) == v:t_func && get(FnKey, 'name') == "ctrlspace#keys#nop#_ExecDbmdexAction"
             let [md, fn] = get(FnKey, 'args')
             let fn = s:modes[md].Enabled ? fn : ''
         elseif type(FnKey) == v:t_string

--- a/autoload/ctrlspace/help.vim
+++ b/autoload/ctrlspace/help.vim
@@ -314,19 +314,18 @@ endfunction
 
 function! s:collectKeysInfo(mapName)
     for key in sort(keys(s:helpMap[a:mapName]))
-        let FnName = s:helpMap[a:mapName][key]
+        let FnKey = s:helpMap[a:mapName][key]
 
-        if type(FnName) == v:t_func && get(FnName, 'name') == "ctrlspace#keys#nop#_ExecException"
-            let excpMode = get(FnName, 'args')[0]
-            let descFunc = get(FnName, 'args')[1]
-            let extrInfo = ' (NOP Mode exception with ' . toupper(excpMode) . ' LIST)'
-        elseif type(FnName) == v:t_string
-            let descFunc = FnName
+        if type(FnKey) == v:t_func && get(FnKey, 'name') == "ctrlspace#keys#nop#_ExecException"
+            let [md, fn] = get(FnKey, 'args')
+            let extrInfo = ' (NOP + ' . toupper(md) . ' Modes Only)'
+        elseif type(FnKey) == v:t_string
+            let fn = FnKey
             let extrInfo = ''
         endif
 
-        if has_key(s:descriptions, descFunc) && !empty(s:descriptions[descFunc])
-            call s:keyHelp(key, s:descriptions[descFunc] . extrInfo)
+        if has_key(s:descriptions, fn) && !empty(s:descriptions[fn])
+            call s:keyHelp(key, s:descriptions[fn] . extrInfo)
         endif
     endfor
 endfunction

--- a/autoload/ctrlspace/keys.vim
+++ b/autoload/ctrlspace/keys.vim
@@ -34,7 +34,7 @@ function! ctrlspace#keys#Init()
     call ctrlspace#keys#workspace#Init()
     call ctrlspace#keys#bookmark#Init()
     call s:initCustomMappings()
-    call ctrlspace#keys#nop#ExceptionsInit()
+    call ctrlspace#keys#nop#DbmdexInit()
 endfunction
 
 function! s:initCustomMappings()

--- a/autoload/ctrlspace/keys.vim
+++ b/autoload/ctrlspace/keys.vim
@@ -34,6 +34,7 @@ function! ctrlspace#keys#Init()
     call ctrlspace#keys#workspace#Init()
     call ctrlspace#keys#bookmark#Init()
     call s:initCustomMappings()
+    call ctrlspace#keys#nop#ExceptionsInit()
 endfunction
 
 function! s:initCustomMappings()

--- a/autoload/ctrlspace/keys/nop.vim
+++ b/autoload/ctrlspace/keys/nop.vim
@@ -37,19 +37,20 @@ function! ctrlspace#keys#nop#ToggleAllModeAndSearch(k)
 endfunction
 
 
-function! ctrlspace#keys#nop#ExceptionsInit() abort
-    call s:AddExceptionMapping("ctrlspace#keys#buffer#MoveTab",       "Buffer", ["+", "-"])
-    call s:AddExceptionMapping("ctrlspace#keys#buffer#SwitchTab",     "Buffer", ["[", "]"])
-    call s:AddExceptionMapping("ctrlspace#keys#file#Refresh",         "File",   ["r"])
+" Dbmdex: DouBle MoDe EXception
+function! ctrlspace#keys#nop#DbmdexInit() abort
+    call s:AddDbmdexMapping("ctrlspace#keys#buffer#MoveTab",       "Buffer", ["+", "-"])
+    call s:AddDbmdexMapping("ctrlspace#keys#buffer#SwitchTab",     "Buffer", ["[", "]"])
+    call s:AddDbmdexMapping("ctrlspace#keys#file#Refresh",         "File",   ["r"])
 endfunction
 
-function! s:AddExceptionMapping(actionName, excpMode, keys) abort
-    call ctrlspace#keys#AddMapping(function('ctrlspace#keys#nop#_ExecException', 
+function! s:AddDbmdexMapping(actionName, excpMode, keys) abort
+    call ctrlspace#keys#AddMapping(function('ctrlspace#keys#nop#_ExecDbmdexAction', 
                                            \ [a:excpMode, a:actionName]), 
                                   \ "Nop", a:keys)
 endfunction
 
-function! ctrlspace#keys#nop#_ExecException(excpMode, actionName, k) abort
+function! ctrlspace#keys#nop#_ExecDbmdexAction(excpMode, actionName, k) abort
     if s:modes[a:excpMode].Enabled
         call function(a:actionName)(a:k)
     else

--- a/autoload/ctrlspace/keys/nop.vim
+++ b/autoload/ctrlspace/keys/nop.vim
@@ -35,3 +35,24 @@ function! ctrlspace#keys#nop#ToggleAllModeAndSearch(k)
         call ctrlspace#keys#buffer#ToggleAllModeAndSearch(a:k)
     endif
 endfunction
+
+
+function! ctrlspace#keys#nop#ExceptionsInit() abort
+    call s:AddExceptionMapping("ctrlspace#keys#buffer#MoveTab",       "Buffer", ["+", "-"])
+    call s:AddExceptionMapping("ctrlspace#keys#buffer#SwitchTab",     "Buffer", ["[", "]"])
+    call s:AddExceptionMapping("ctrlspace#keys#file#Refresh",         "File",   ["r"])
+endfunction
+
+function! s:AddExceptionMapping(actionName, excpMode, keys) abort
+    call ctrlspace#keys#AddMapping(function('ctrlspace#keys#nop#_ExecException', 
+                                           \ [a:excpMode, a:actionName]), 
+                                  \ "Nop", a:keys)
+endfunction
+
+function! ctrlspace#keys#nop#_ExecException(excpMode, actionName, k) abort
+    if s:modes[a:excpMode].Enabled
+        call function(a:actionName)(a:k)
+    else
+        call ctrlspace#keys#Undefined(a:k)
+    endif
+endfunction

--- a/autoload/ctrlspace/keys/nop.vim
+++ b/autoload/ctrlspace/keys/nop.vim
@@ -37,19 +37,27 @@ function! ctrlspace#keys#nop#ToggleAllModeAndSearch(k)
 endfunction
 
 
+" -----------------------------
 " Dbmdex: DouBle MoDe EXception
+" -----------------------------
+
+" Define NOP + <Mode> excepted mappings in the following Initiator
 function! ctrlspace#keys#nop#DbmdexInit() abort
     call s:AddDbmdexMapping("ctrlspace#keys#buffer#MoveTab",       "Buffer", ["+", "-"])
     call s:AddDbmdexMapping("ctrlspace#keys#buffer#SwitchTab",     "Buffer", ["[", "]"])
     call s:AddDbmdexMapping("ctrlspace#keys#file#Refresh",         "File",   ["r"])
 endfunction
 
+" Function used to add these Dbmdex mappings
+" Its signature is the same as that of ctrlspace#keys#AddMapping
 function! s:AddDbmdexMapping(actionName, excpMode, keys) abort
     call ctrlspace#keys#AddMapping(function('ctrlspace#keys#nop#_ExecDbmdexAction', 
                                            \ [a:excpMode, a:actionName]), 
                                   \ "Nop", a:keys)
 endfunction
 
+" Function that wraps the action normally available in <Mode>, and makes it
+" available when CtrlSpace is in the double-mode enabled state of NOP + <Mode>
 function! ctrlspace#keys#nop#_ExecDbmdexAction(excpMode, actionName, k) abort
     if s:modes[a:excpMode].Enabled
         call function(a:actionName)(a:k)

--- a/autoload/ctrlspace/keys/nop.vim
+++ b/autoload/ctrlspace/keys/nop.vim
@@ -41,7 +41,8 @@ endfunction
 " Dbmdex: DouBle MoDe EXception
 " -----------------------------
 
-" Define NOP + <Mode> excepted mappings in the following Initiator
+" Define keymappings for combined NOP+<Mode> mode inside the following Initiator,
+" where <Mode> is a ListView mode such as BUFFER, FILE, BOOKMARK, etc.
 function! ctrlspace#keys#nop#DbmdexInit() abort
     call s:AddDbmdexMapping("ctrlspace#keys#buffer#MoveTab",       "Buffer", ["+", "-"])
     call s:AddDbmdexMapping("ctrlspace#keys#buffer#SwitchTab",     "Buffer", ["[", "]"])


### PR DESCRIPTION
* provide API for adding reasonable keymappings in Nop Mode as exceptions
* added keymappings will only work in the explicitly excepted modes
* added 3 sets of exceptions (2 for Buffer, 1 for File) as examples