### PR TITLE
Revert: lambda -> eval()

### DIFF
--- a/autoload/ctrlspace/changebuftab.vim
+++ b/autoload/ctrlspace/changebuftab.vim
@@ -7,22 +7,22 @@ let s:WrapEnabled = ctrlspace#context#Configuration().ChangeBufTabWrapsAround
 function! s:genCpOrMvBufToTabCmdmap(funcstr)
     let l:ct = tabpagenr()      " ct: current tab
     let l:lt = tabpagenr('$')   " lt: last tab
-    return  { 'nb': eval("l:ct-1 > 0      ? 'call '.a:funcstr.'('.(l:ct-1).')' : ''"),
-            \ 'nf': eval("l:ct+1 < l:lt+1 ? 'call '.a:funcstr.'('.(l:ct+1).')' : ''"),
+    return  { 'nb': {-> l:ct-1 > 0      ? 'call '.a:funcstr.'('.(l:ct-1).')' : ''}(),
+            \ 'nf': {-> l:ct+1 < l:lt+1 ? 'call '.a:funcstr.'('.(l:ct+1).')' : ''}(),
             \ 'wb': 'call '.a:funcstr.'('.l:lt.')',
             \ 'wf': 'call '.a:funcstr.'(1)', }
 endfunction
 
 function! s:genSwitchTabCmdmap(tabBwd, tabFwd)
-    return  { 'nb': eval("tabpagenr() != 1              ? a:tabBwd : ''"),
-            \ 'nf': eval("tabpagenr() != tabpagenr('$') ? a:tabFwd : ''"),
+    return  { 'nb': {-> tabpagenr() != 1              ? a:tabBwd : ''}(),
+            \ 'nf': {-> tabpagenr() != tabpagenr('$') ? a:tabFwd : ''}(),
             \ 'wb': a:tabBwd,
             \ 'wf': a:tabFwd, }
 endfunction
 
 function! s:genMoveTabCmdmap(tmvBwd, tmvFwd)
-    return { 'nb': eval("tabpagenr() != 1              ? a:tmvBwd : ''"),
-           \ 'nf': eval("tabpagenr() != tabpagenr('$') ? a:tmvFwd : ''"),
+    return { 'nb': {-> tabpagenr() != 1              ? a:tmvBwd : ''}(),
+           \ 'nf': {-> tabpagenr() != tabpagenr('$') ? a:tmvFwd : ''}(),
            \ 'wb': 'tabm $',
            \ 'wf': 'tabm 0', }
 endfunction


### PR DESCRIPTION
This reverts commit `Remove lambdas`, hash `12d310f0256c6a606b3934e9ff0c5652abfa27a9` in PR #242; i.e. lambdas should/would be used instead of `eval()`.