### PR TITLE
Fix bugs of 1st March changes

### DIFF
--- a/autoload/ctrlspace/util.vim
+++ b/autoload/ctrlspace/util.vim
@@ -2,21 +2,19 @@ let s:config = ctrlspace#context#Configuration()
 let s:modes  = ctrlspace#modes#Modes()
 
 function! ctrlspace#util#system(cmd, ...)
-    if has('win32')
-        if &shell !~? 'cmd'
-            let saved_shell = [
-                \ &shell,
-                \ &shellcmdflag,
-                \ &shellxquote,
-                \ &shellxescape,
-                \ &shellquote,
-                \ &shellpipe,
-                \ &shellredir,
-                \ &shellslash
-                \]
-            set shell& shellcmdflag& shellxquote& shellxescape&
-            set shellquote& shellpipe& shellredir& shellslash&
-        endif
+    if has('win32') && &shell !~? 'cmd'
+        let saved_shell = [
+            \ &shell,
+            \ &shellcmdflag,
+            \ &shellxquote,
+            \ &shellxescape,
+            \ &shellquote,
+            \ &shellpipe,
+            \ &shellredir,
+            \ &shellslash
+            \]
+        set shell& shellcmdflag& shellxquote& shellxescape&
+        set shellquote& shellpipe& shellredir& shellslash&
     endif
 
     let output = a:0 > 0 ? system(a:cmd, a:1) : system(a:cmd)
@@ -30,7 +28,6 @@ function! ctrlspace#util#system(cmd, ...)
             \ &shellpipe,
             \ &shellredir,
             \ &shellslash ] = saved_shell
-        endif
     endif
 
     return has('win32') ? substitute(output, "\r", '', 'g') : output

--- a/autoload/ctrlspace/util.vim
+++ b/autoload/ctrlspace/util.vim
@@ -1,6 +1,3 @@
-let s:config = ctrlspace#context#Configuration()
-let s:modes  = ctrlspace#modes#Modes()
-
 function! ctrlspace#util#system(cmd, ...)
     if has('win32') && &shell !~? 'cmd'
         let saved_shell = [
@@ -100,11 +97,12 @@ function! ctrlspace#util#ChDir(dir)
 endfunction
 
 function! s:internalFilePath(name)
+    let config = ctrlspace#context#Configuration()
     let root = ctrlspace#roots#CurrentProjectRoot()
     let fullPart = empty(root) ? "" : (root . "/")
 
-    if !empty(s:config.ProjectRootMarkers)
-        for candidate in s:config.ProjectRootMarkers
+    if !empty(config.ProjectRootMarkers)
+        for candidate in config.ProjectRootMarkers
             let candidatePath = fullPart . candidate
 
             if isdirectory(candidatePath)
@@ -143,6 +141,7 @@ endfunction
 
 function! ctrlspace#util#SetStatusline()
     if has("statusline")
-        silent! exe "let &l:statusline = " . s:config.StatuslineFunction
+        let config = ctrlspace#context#Configuration()
+        silent! exe "let &l:statusline = " . config.StatuslineFunction
     endif
 endfunction

--- a/autoload/ctrlspace/util.vim
+++ b/autoload/ctrlspace/util.vim
@@ -20,19 +20,20 @@ function! ctrlspace#util#system(cmd, ...)
     endif
 
     let output = a:0 > 0 ? system(a:cmd, a:1) : system(a:cmd)
-    return has('win32') ? substitute(output, "\r", '', 'g') : output
 
     if exists('saved_shell')
-        let [   &shell,
+        let [ &shell,
             \ &shellcmdflag,
             \ &shellxquote,
             \ &shellxescape,
             \ &shellquote,
             \ &shellpipe,
             \ &shellredir,
-            \ &shellslash] = saved_shell
+            \ &shellslash ] = saved_shell
         endif
     endif
+
+    return has('win32') ? substitute(output, "\r", '', 'g') : output
 endfunction
 
 function! ctrlspace#util#NormalizeDirectory(directory)


### PR DESCRIPTION
It fixes #260

1. Remove circular dependency between `util.vim` and `context.vim` by deferring call of `ctrlspace#context#Configuration()` in `util.vim` (`context.vim` calls `ctrlspace#util#system` at module loading time, see `s:init` and `s:detectEngine`)
2. Fix unreachable restoring of `shell*` options (unreachable due to `return` above that block of code) in `ctrlspace#util#system`
3. Remove extra `endif` in `ctrlspace#util#system` after `let`