### PR TITLE
Add option to disable file caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ To find more about setting up the file engines, check:
 :help g:CtrlSpaceFileEngine
 ```
 
+Lastly, this file engine sources the list of files it searches through from
+a text file cache (`cs_files`, typically stored under `.git/`). For small to
+medium-sized projects (say <1k files as a cautious estimate), where loading
+from this files cache isn't likely to yield a noticeable speed boost, and you
+might instead rather not think about when to refresh the cache (for instance
+on switching to a branch with different files), you may disable the cache and
+by extension forgo using the Go file engine by setting the option below:
+
+```VimL
+let g:CtrlSpaceEnableFilesCache = 0
+```
+
 ## Symbols
 
 Vim-Ctrlspace displays icons in the UI if your font supports UTF8, or
@@ -262,7 +274,7 @@ They can be used by adding the following lines to `vimrc`:
 
 ```VimL
 if executable('rg')
-    let g:CtrlSpaceGlobCommand = 'rg --files'
+    let g:CtrlSpaceGlobCommand = 'rg --color=never --files'
 elseif executable('fd')
     let g:CtrlSpaceGlobCommand = 'fd --type=file --color=never'
 elseif executable('ag')

--- a/autoload/ctrlspace/cache.vim
+++ b/autoload/ctrlspace/cache.vim
@@ -1,0 +1,164 @@
+let s:config = ctrlspace#context#Configuration()
+
+
+" public API exporting the appropriate cache system
+
+function! ctrlspace#cache#Init() abort
+  let cache = s:config.EnableFilesCache ? s:file_cache : s:null_cache
+  call s:cache_common(cache)
+  return cache
+endfunction
+
+function! s:cache_common(cache) abort
+  let a:cache.files = []
+  let a:cache.items = []
+  let a:cache.clear_all = function('s:clear_all')
+  let a:cache.get_files = function('s:get_files')
+  let a:cache.get_items = function('s:get_items')
+  let a:cache.map_files2items = function('s:map_files2items')
+endfunction
+
+function! s:clear_all() dict abort
+    let self.files = []
+    let self.items = []
+endfunction
+
+function! s:get_files() dict abort
+    return self.files
+endfunction
+
+function! s:get_items() dict abort
+    return self.items
+endfunction
+
+function! s:map_files2items() dict abort
+    let self.items = map(copy(self.files), '{ "index": v:key, "text": v:val, "indicators": "" }')
+endfunction
+
+
+" script local helper used for globbing in both cache systems
+
+function! s:glob_project_files() abort
+    let uniqueFiles = {}
+    for fname in empty(s:glob_cmd) ? split(globpath('.', '**'), '\n') : split(ctrlspace#util#system(s:glob_cmd), '\n')
+        let fnameModified = fnamemodify(fname, ":.")
+        if isdirectory(fnameModified) || (fnameModified =~# s:config.IgnoredFiles)
+            continue
+        endif
+        let uniqueFiles[fnameModified] = 1
+    endfor
+    return keys(uniqueFiles)
+endfunction
+
+
+" detect available system glob command and set
+
+function! s:set_globber() abort
+  if !empty(s:config.GlobCommand)
+      let glob_cmd = s:config.GlobCommand
+  elseif executable('rg')
+      let glob_cmd = 'rg --color=never --files'
+  elseif executable('fd')
+      let glob_cmd = 'fd --color=never --type=file'
+  elseif executable('ag')
+      let glob_cmd = 'ag -l --nocolor -g ""'
+  else
+      let glob_cmd = ''
+  endif
+  return [glob_cmd, s:get_glob_bin_name(glob_cmd)]
+endfunction
+
+function! s:get_glob_bin_name(glob_cmd) abort
+  if empty(a:glob_cmd)
+      return "Vim's globpath()"
+  elseif len(a:glob_cmd) > 1
+      let bin = a:glob_cmd[:1]
+      if index(['rg', 'fd', 'ag'], bin) >= 0
+          return { 'rg': 'rg (ripgrep)',
+                 \ 'fd': 'fd (fd-find)',
+                 \ 'ag': 'ag (The Silver Searcher)', }[bin]
+      endif
+  endif
+  return "unknown grepper/finder"
+endfunction
+
+let [s:glob_cmd, s:glob_bin] = s:set_globber()
+
+
+" CtrlSpace's default built-in file cache
+let s:file_cache = {}
+
+function! s:file_cache.save() dict abort
+    let filename = ctrlspace#util#FilesCache()
+    if empty(filename)
+        return
+    endif
+    call writefile(self.files, filename)
+endfunction
+
+function! s:file_cache.load() dict abort
+    let filename = ctrlspace#util#FilesCache()
+    if empty(filename) || !filereadable(filename)
+        return
+    endif
+    let self.files = readfile(filename)
+endfunction
+
+function! s:file_cache.collect() dict abort
+    if empty(self.files)
+        let self.items = []
+
+        " try to pick up files from cache
+        call self.load()  " calls s:file_cache.load()
+        if empty(self.files)
+            let action = "Collecting & caching files..."
+            call ctrlspace#ui#Msg(action)
+            let self.files = s:glob_project_files()
+            call self.save()  " calls s:file_cache.save()
+        else
+            let action = "Loading cached files..."
+            call ctrlspace#ui#Msg(action)
+        endif
+        call self.map_files2items()
+
+        redraw!
+        call ctrlspace#ui#Msg(action . " Done (" . len(self.files) . ").")
+    endif
+endfunction
+
+function! s:file_cache.refresh() dict abort
+    let self.files = []
+    call self.save()  " calls s:file_cache.save()
+endfunction
+
+
+" no operations cache: functionally equivalent to disabling the cache
+let s:null_cache = {}
+
+function! s:null_cache.save() abort
+    return
+endfunction
+
+function! s:null_cache.load() dict abort
+    let self.files = s:glob_project_files()
+endfunction
+
+function! s:null_cache.collect() dict abort
+    if !exists('s:null_cache_alerted')
+        let action = "Collecting files using " . s:glob_bin . "..."
+        call ctrlspace#ui#Msg(action)
+    endif
+
+    call self.load()  " calls s:null_cache.load()
+    call self.map_files2items()
+
+    if !exists('s:null_cache_alerted')
+        redraw!
+        call ctrlspace#ui#Msg(action . " Done (" . len(self.files) . ").")
+        let s:null_cache_alerted = 'DEFINED'  " defined to suppress future status message
+    endif
+endfunction
+
+function! s:null_cache.refresh() abort
+    unlet s:null_cache_alerted
+endfunction

--- a/autoload/ctrlspace/context.vim
+++ b/autoload/ctrlspace/context.vim
@@ -56,6 +56,7 @@ let s:configuration = {
                     \ "Help":                      {},
                     \ "SortHelp":                  0,
                     \ "GlobCommand":               "",
+                    \ "EnableFilesCache":          1,
                     \ "UseTabline":                1,
                     \ "UseArrowsInTerm":           0,
                     \ "UseMouseAndArrowsInTerm":   0,

--- a/autoload/ctrlspace/engine.vim
+++ b/autoload/ctrlspace/engine.vim
@@ -8,7 +8,7 @@ endif
 
 " returns [patterns, indices, size, text]
 function! ctrlspace#engine#Content() abort
-    if !empty(s:config.FileEngine) && s:modes.File.Enabled
+    if s:config.EnableFilesCache && s:modes.File.Enabled
         return s:contentFromFileEngine()
     endif
 

--- a/doc/ctrlspace.txt
+++ b/doc/ctrlspace.txt
@@ -1,4 +1,4 @@
-*ctrlspace.txt*           For Vim version 7.3+      Last change: 2020.01.09
+*ctrlspace.txt*           For Vim version 7.3+      Last change: 2020.12.01
 *ctrlspace*
 *vim-ctrlspace*
 
@@ -60,25 +60,26 @@ Table of Contents                                            *ctrlspace-toc*
    7.5 g:CtrlSpaceKeys                                     |g:CtrlSpaceKeys|
    7.6 g:CtrlSpaceHelp                                     |g:CtrlSpaceHelp|
    7.7 g:CtrlSpaceGlobCommand                       |g:CtrlSpaceGlobCommand|
-   7.8 g:CtrlSpaceUseTabline                         |g:CtrlSpaceUseTabline|
-   7.9 g:CtrlSpaceUseArrowsInTerm               |g:CtrlSpaceUseArrowsInTerm|
-   7.10 g:CtrlSpaceUseMouseAndArrowsInTerm
+   7.8 g:CtrlSpaceEnableFilesCache             |g:CtrlSpaceEnableFilesCache|
+   7.9 g:CtrlSpaceUseTabline                         |g:CtrlSpaceUseTabline|
+   7.10 g:CtrlSpaceUseArrowsInTerm              |g:CtrlSpaceUseArrowsInTerm|
+   7.11 g:CtrlSpaceUseMouseAndArrowsInTerm
                                         |g:CtrlSpaceUseMouseAndArrowsInTerm|
-   7.11 g:CtrlSpaceSaveWorkspaceOnExit      |g:CtrlSpaceSaveWorkspaceOnExit|
-   7.12 g:CtrlSpaceSaveWorkspaceOnSwitch  |g:CtrlSpaceSaveWorkspaceOnSwitch|
-   7.13 g:CtrlSpaceLoadLastWorkspaceOnStart
+   7.12 g:CtrlSpaceSaveWorkspaceOnExit      |g:CtrlSpaceSaveWorkspaceOnExit|
+   7.13 g:CtrlSpaceSaveWorkspaceOnSwitch  |g:CtrlSpaceSaveWorkspaceOnSwitch|
+   7.14 g:CtrlSpaceLoadLastWorkspaceOnStart
                                        |g:CtrlSpaceLoadLastWorkspaceOnStart|
-   7.14 g:CtrlSpaceEnableBufferTabWrapAround
+   7.15 g:CtrlSpaceEnableBufferTabWrapAround
                                       |g:CtrlSpaceEnableBufferTabWrapAround|
-   7.15 g:CtrlSpaceCacheDir                            |g:CtrlSpaceCacheDir|
-   7.16 g:CtrlSpaceProjectRootMarkers        |g:CtrlSpaceProjectRootMarkers|
-   7.17 g:CtrlSpaceUseUnicode                        |g:CtrlSpaceUseUnicode|
-   7.18 g:CtrlSpaceSymbols                              |g:CtrlSpaceSymbols|
-   7.19 g:CtrlSpaceIgnoredFiles                    |g:CtrlSpaceIgnoredFiles|
-   7.20 g:CtrlSpaceStatuslineFunction        |g:CtrlSpaceStatuslineFunction|
-   7.21 g:CtrlSpaceSearchTiming                    |g:CtrlSpaceSearchTiming|
-   7.22 g:CtrlSpaceFileEngine                        |g:CtrlSpaceFileEngine|
-   7.23 g:CtrlSpaceSortHelp                            |g:CtrlSpaceSortHelp|
+   7.16 g:CtrlSpaceCacheDir                            |g:CtrlSpaceCacheDir|
+   7.17 g:CtrlSpaceProjectRootMarkers        |g:CtrlSpaceProjectRootMarkers|
+   7.18 g:CtrlSpaceUseUnicode                        |g:CtrlSpaceUseUnicode|
+   7.19 g:CtrlSpaceSymbols                              |g:CtrlSpaceSymbols|
+   7.20 g:CtrlSpaceIgnoredFiles                    |g:CtrlSpaceIgnoredFiles|
+   7.21 g:CtrlSpaceStatuslineFunction        |g:CtrlSpaceStatuslineFunction|
+   7.22 g:CtrlSpaceSearchTiming                    |g:CtrlSpaceSearchTiming|
+   7.23 g:CtrlSpaceFileEngine                        |g:CtrlSpaceFileEngine|
+   7.24 g:CtrlSpaceSortHelp                            |g:CtrlSpaceSortHelp|
  8. API                                                      |ctrlspace-api|
    8.1 Commands                                         |ctrlspace-commands|
      8.1.1 :CtrlSpace [keys]                                    |:CtrlSpace|
@@ -917,7 +918,25 @@ You can even make `Ag` to show hidden files by providing `--hidden` option: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.8 *g:CtrlSpaceUseTabline*
+7.8 *g:CtrlSpaceEnableFilesCache*
+
+Enable to store a cache file (cs_files) inside .git/ of each project. More
+suited for very large projects (>10k+ files at least, likely even more).
+
+Disable to load project files by simply re-globbing each time FILE mode is
+activated. More suited for small to medium sized projects, or for projects
+where switching to branches with different file layouts is common.
+
+Supported globbers are: rg, fd & ag (auto-detected in that order)
+
+Default value: >
+
+    let g:CtrlSpaceEnableFilesCache = 1
+<
+                                                             |ctrlspace-toc|
+--------------------------------------------------------------------------
+
+7.9 *g:CtrlSpaceUseTabline*
 
 Should Vim-CtrlSpace change your default tabline to its own?
 
@@ -928,7 +947,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.9 *g:CtrlSpaceUseArrowsInTerm*
+7.10 *g:CtrlSpaceUseArrowsInTerm*
 
 Should the plugin use arrows and <Home>, <End>, <PageUp>, <PageDown> keys
 in a terminal Vim.
@@ -940,7 +959,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.10 *g:CtrlSpaceUseMouseAndArrowsInTerm*
+7.11 *g:CtrlSpaceUseMouseAndArrowsInTerm*
 
 Should the plugin use mouse, arrows and <Home>, <End>, <PageUp>,
 <PageDown> keys in a terminal Vim. Disables the <Esc> key if turned on.
@@ -952,7 +971,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.11 *g:CtrlSpaceSaveWorkspaceOnExit*
+7.12 *g:CtrlSpaceSaveWorkspaceOnExit*
 
 Saves the active workspace (if present) on Vim quit. If this option is
 set, the Vim quit (<Q>) action in the plugin does not check for workspace
@@ -965,7 +984,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.12 *g:CtrlSpaceSaveWorkspaceOnSwitch*
+7.13 *g:CtrlSpaceSaveWorkspaceOnSwitch*
 
 Saves the active workspace (if present) on switching to another workspace
 or clearing (closing) the current one. If this option is set, the plugin
@@ -978,7 +997,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.13 *g:CtrlSpaceLoadLastWorkspaceOnStart*
+7.14 *g:CtrlSpaceLoadLastWorkspaceOnStart*
 
 Loads the last active workspace (if found) on Vim startup.
 
@@ -989,7 +1008,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.14 *g:CtrlSpaceEnableBufferTabWrapAround*
+7.15 *g:CtrlSpaceEnableBufferTabWrapAround*
 
 Determines whether changing (i.e. switching, moving or copying) buffers or
 tabs in BUFFER and TAB LIST modes wraps-around when the active/selected
@@ -1006,7 +1025,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.15 *g:CtrlSpaceCacheDir*
+7.16 *g:CtrlSpaceCacheDir*
 
 A directory for the Vim-CtrlSpace cache file (`.cs_cache`). By default
 your `$HOME` directory will be used.
@@ -1018,7 +1037,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.16 *g:CtrlSpaceProjectRootMarkers*
+7.17 *g:CtrlSpaceProjectRootMarkers*
 
 An array of directory names which presence indicates the project root. If
 no marker is found, you will be asked to confirm the project root
@@ -1042,7 +1061,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.17 *g:CtrlSpaceUseUnicode*
+7.18 *g:CtrlSpaceUseUnicode*
 
 Set to `1` if you want to use Unicode symbols, or `0` otherwise.
 
@@ -1053,7 +1072,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.18 *g:CtrlSpaceSymbols*
+7.19 *g:CtrlSpaceSymbols*
 
 Enables you to provide your own symbols. It's useful if, for example, your
 font doesn't contain enough symbols or the glyphs are poorly rendered.
@@ -1093,7 +1112,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.19 *g:CtrlSpaceIgnoredFiles*
+7.20 *g:CtrlSpaceIgnoredFiles*
 
 The expression used to ignore some files during file collecting. It is
 used in addition to the `wildignore` option in Vim (see |wildignore|).
@@ -1108,7 +1127,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.20 *g:CtrlSpaceStatuslineFunction*
+7.21 *g:CtrlSpaceStatuslineFunction*
 
 Allows to provide custom statusline function used by the CtrlSpace window.
 
@@ -1119,7 +1138,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.21 *g:CtrlSpaceSearchTiming*
+7.22 *g:CtrlSpaceSearchTiming*
 
 Allows you to adjust search smoothness by providing a delay on search
 input. By default the delay is set to 200 ms. That way the plugin ensures
@@ -1132,7 +1151,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.22 *g:CtrlSpaceFileEngine*
+7.23 *g:CtrlSpaceFileEngine*
 
 The plugin provides fuzzy search engine written in Go and compiled for
 several architectures:
@@ -1190,7 +1209,7 @@ Default value: >
                                                              |ctrlspace-toc|
 --------------------------------------------------------------------------
 
-7.23 *g:CtrlSpaceSortHelp*
+7.24 *g:CtrlSpaceSortHelp*
 
 Enables sorting the lines in help mode by the description. This is disabled by
 default for backwards compatibility. In a future version sorting might become


### PR DESCRIPTION
The motivation for this feature is that, with new powerful grepping / file-finding tools such as `rg` & `fd` (and to a lesser extent `ag`) now widely available for most OS platforms, it has become increasingly unnecessary to use the dedicated `cs_files` cache file for projects.

For small sized projects (say <1k files), there is effectively zero benefit, and arguably even a slight detriment, since file layouts/structures of smaller projects tend to undergo more flux, thereby requiring users to manually refresh their cache more often, which can become an annoyance (this is true at least for myself).

For medium sized projects (say <10k files), the cache can start to make some sense, since a slight but noticeable delay from file globbing does become more perceptible (on my quad-core i5-6200U machine that is); though the delay is still well under a second.

Most people tend to work on smaller projects primarily; and even those that do work on medium and large projects probably have more smaller sized projects on their hands. Thus being able to disable the file cache is quite a useful option IMO.

As of now, `g:CtrlSpaceEnableFilesCache` is an all or nothing option, so users themselves will have to judge if it makes more sense to turn it on or off for all the projects they work on. However sometime in the future, I'd like to add the ability for users to customize file caching on a per project basis.