### PR TITLE
bugfix: Stop executing t:CtrlSpaceWinrestcmd

### DIFF
--- a/autoload/ctrlspace/window.vim
+++ b/autoload/ctrlspace/window.vim
@@ -134,6 +134,10 @@ endfunction
 function! ctrlspace#window#GoToStartWindow() abort
     silent! exe t:CtrlSpaceStartWindow . "wincmd w"
 
+    if winrestcmd() != t:CtrlSpaceWinrestcmd && !has('nvim')
+        silent! exe t:CtrlSpaceWinrestcmd
+    endif
+
     if winrestcmd() != t:CtrlSpaceWinrestcmd
         wincmd =
     endif

--- a/autoload/ctrlspace/window.vim
+++ b/autoload/ctrlspace/window.vim
@@ -135,11 +135,7 @@ function! ctrlspace#window#GoToStartWindow() abort
     silent! exe t:CtrlSpaceStartWindow . "wincmd w"
 
     if winrestcmd() != t:CtrlSpaceWinrestcmd
-        silent! exe t:CtrlSpaceWinrestcmd
-
-        if winrestcmd() != t:CtrlSpaceWinrestcmd
-            wincmd =
-        endif
+        wincmd =
     endif
 endfunction
 


### PR DESCRIPTION
- Previously this caused an interaction with other plugins where if they opened other windows this would cause ctrlspace to shrink windows to the minimum size
- (From :help winrestcmd()) "Only works properly when no windows are opened or closed and the current window and tab page is unchanged"
- From testing in https://github.com/vim-ctrlspace/vim-ctrlspace/issues/271 it seems that this line is not required, so this commit removes it
- This PR will close #271 