### PR TITLE
fix: make ctrlspace restore the buffer after processing arguments

### DIFF
--- a/autoload/ctrlspace/init.vim
+++ b/autoload/ctrlspace/init.vim
@@ -52,7 +52,7 @@ function! ctrlspace#init#Init() abort
         endif
         execute 'buffer ' . currBuff
 
-        autocmd CtrlSpaceInit VimEnter * silent argdo call ctrlspace#buffers#AddBuffer()
+        autocmd CtrlSpaceInit VimEnter * silent argdo call ctrlspace#buffers#AddBuffer() | rewind
     endif
 
     autocmd CtrlSpaceInit BufEnter * call ctrlspace#buffers#AddBuffer()


### PR DESCRIPTION
when invoked with multiple arguments, i.e. as `vim -O file1.txt file2.txt` ctrlspace causes both the panels to show `file2.txt`. I've added a call to `rewind` command after `argdo` so the proper files are restored in the windows.