### PR TITLE
Add count prefix when navigating up or down

### DIFF
--- a/autoload/ctrlspace/keys/common.vim
+++ b/autoload/ctrlspace/keys/common.vim
@@ -44,7 +44,15 @@ function! ctrlspace#keys#common#Init() abort
     call s:map("ToggleBookmarkMode",           "b")
     call s:map("ToggleBookmarkModeAndSearch",  "B")
 
+    call s:map("CountPrefix1",                 "1")
     call s:map("CountPrefix2",                 "2")
+    call s:map("CountPrefix3",                 "3")
+    call s:map("CountPrefix4",                 "4")
+    call s:map("CountPrefix5",                 "5")
+    call s:map("CountPrefix6",                 "6")
+    call s:map("CountPrefix7",                 "7")
+    call s:map("CountPrefix8",                 "8")
+    call s:map("CountPrefix9",                 "9")
 
     let keyMap  = ctrlspace#keys#KeyMap()
     let helpMap = ctrlspace#help#HelpMap()
@@ -293,22 +301,47 @@ function! ctrlspace#keys#common#ToggleBookmarkModeAndSearch(k) abort
     return s:toggleListViewAndSearch(a:k, "Bookmark")
 endfunction
 
+function! ctrlspace#keys#common#CountPrefix1(k) abort
+  return s:CountPrefix(1)
+endfunction
 function! ctrlspace#keys#common#CountPrefix2(k) abort
-  let count = 0
+  return s:CountPrefix(2)
+endfunction
+function! ctrlspace#keys#common#CountPrefix3(k) abort
+  return s:CountPrefix(3)
+endfunction
+function! ctrlspace#keys#common#CountPrefix4(k) abort
+  return s:CountPrefix(4)
+endfunction
+function! ctrlspace#keys#common#CountPrefix5(k) abort
+  return s:CountPrefix(5)
+endfunction
+function! ctrlspace#keys#common#CountPrefix6(k) abort
+  return s:CountPrefix(6)
+endfunction
+function! ctrlspace#keys#common#CountPrefix7(k) abort
+  return s:CountPrefix(7)
+endfunction
+function! ctrlspace#keys#common#CountPrefix8(k) abort
+  return s:CountPrefix(8)
+endfunction
+function! ctrlspace#keys#common#CountPrefix9(k) abort
+  return s:CountPrefix(9)
+endfunction
+
+function! s:CountPrefix(maxCount) abort
+  let l:count = 0
   " Get character input. (Only one character is accepted. See `:h getchar`.)
   let charInput = nr2char(getchar())
 
   " Check if the input character is either k or j
   if charInput == "k" || charInput == "j"
-    while count < 2
-      if charInput == "k"
-        call ctrlspace#window#MoveSelectionBar("up")
-      elseif charInput == "j"
-        call ctrlspace#window#MoveSelectionBar("down")
-      endif
-      let count += 1
+    " Process input character up to maxCount times
+    while l:count < a:maxCount
+      " Move selection bar up or down based on input
+      call ctrlspace#window#MoveSelectionBar(charInput == "k" ? "up" : "down")
+      let l:count += 1
     endwhile
-
   " If the input character is not k or j, print warning
   else
     echo 'Only "k" or "j" available'

--- a/autoload/ctrlspace/keys/common.vim
+++ b/autoload/ctrlspace/keys/common.vim
@@ -44,6 +44,8 @@ function! ctrlspace#keys#common#Init() abort
     call s:map("ToggleBookmarkMode",           "b")
     call s:map("ToggleBookmarkModeAndSearch",  "B")
 
+    call s:map("CountPrefix2",                 "2")
+
     let keyMap  = ctrlspace#keys#KeyMap()
     let helpMap = ctrlspace#help#HelpMap()
 
@@ -289,6 +291,29 @@ endfunction
 
 function! ctrlspace#keys#common#ToggleBookmarkModeAndSearch(k) abort
     return s:toggleListViewAndSearch(a:k, "Bookmark")
+endfunction
+
+function! ctrlspace#keys#common#CountPrefix2(k) abort
+  let count = 0
+  " Get character input. (Only one character is accepted. See `:h getchar`.)
+  let charInput = nr2char(getchar())
+
+  " Check if the input character is either k or j
+  if charInput == "k" || charInput == "j"
+    while count < 2
+      if charInput == "k"
+        call ctrlspace#window#MoveSelectionBar("up")
+      elseif charInput == "j"
+        call ctrlspace#window#MoveSelectionBar("down")
+      endif
+      let count += 1
+    endwhile
+
+  " If the input character is not k or j, print warning
+  else
+    echo 'Only "k" or "j" available'
+  endif
+  return 1
 endfunction
 
 function! ctrlspace#keys#common#ToggleBookmarkMode(k) abort


### PR DESCRIPTION
Use `getchar` to get the countprefix for navigation. Using `getchar` makes navigation with countprefix a lot more vim-like than using `input()`. (See https://github.com/vim-ctrlspace/vim-ctrlspace/pull/315#issue-2216704563)